### PR TITLE
Optional cython for runtime

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include cystatsd *.hpp
 recursive-include cystatsd *.pyx
 recursive-include cystatsd *.pxd
+recursive-include cystatsd *.cpp

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 clean:
 	rm -rf build dist
-	rm -f cystatsd/collector/collector.cpp MANIFEST *.egg-info *.tar.gz 
+	rm -f cystatsd/collector/collector.cpp MANIFEST *.egg-info *.tar.gz
 
 test: clean
 	python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,49 @@
-from Cython.Build import cythonize
 from distutils.core import setup, Extension
+from distutils.command.sdist import sdist as _sdist
+import copy
+
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    use_cython = False
+else:
+    use_cython = True
 
 OPTIMIZED = '-O2'
 UNOPTIMIZED = '-O0'
 OPTIMIZATION = OPTIMIZED
 
-STATS_EXT = cythonize(Extension("cystatsd.collector.collector", sources=[
-        "cystatsd/collector/collector.pyx",
-        "cystatsd/collector/statsd_proto.cpp"
-    ],
-    language="c++",
-    include_dirs=["cystatsd/collector"],
-    extra_compile_args=[OPTIMIZATION, "--std=c++11"]
-))
+
+extension = Extension(
+	"cystatsd.collector.collector",
+	sources = [
+		"cystatsd/collector/collector.pyx",
+		"cystatsd/collector/statsd_proto.cpp",
+	],
+	language="c++",
+	include_dirs=["cystatsd/collector"],
+	extra_compile_args=[OPTIMIZATION, "--std=c++11"]
+)
+
+
+if use_cython:
+    STATS_EXT = cythonize(extension)
+else:
+    extension_copy = copy.deepcopy(extension)
+    extension_copy.sources = [
+		"cystatsd/collector/statsd_proto.cpp",
+		"cystatsd/collector/collector.cpp",
+	]
+    STATS_EXT = [extension_copy]
+
+
+class sdist(_sdist):
+    def run(self):
+        # Make sure the compiled Cython files in the distribution are up-to-date
+        from Cython.Build import cythonize
+        cythonize(extension)
+        _sdist.run(self)
+
 
 setup(
     name='cystatsd',
@@ -27,11 +58,14 @@ setup(
     author_email='scott.ivey@gmail.com',
     license='MIT',
     package_data={
-        'cystatsd': ['*.pyx', '*.pxd', '*.hpp', '*.pxd', '*.py']
+        'cystatsd': ['*.pyx', '*.pxd', '*.hpp', '*.pxd', '*.py', '*.cpp']
     },
     packages=[
         'cystatsd', 'cystatsd.collector'
     ],
     ext_modules=STATS_EXT,
-    provides=['cystatsd']
+    provides=['cystatsd'],
+	cmdclass={
+		'sdist': sdist
+	},
 )


### PR DESCRIPTION
`cystatsd` does not have to depend on cython for user. If we include generated file `cystatsd/collector/collector.cpp` we can ship `cystatsd` without cython. However, if user has cython installed it will be used to regenerate that file. You can find information about this in http://stackoverflow.com/questions/4505747/how-should-i-structure-a-python-package-that-contains-cython-code . This is even recommended by cython itself http://docs.cython.org/en/latest/src/reference/compilation.html#distributing-cython-modules . You won't to regenerate that file when something changes because I edited implementation of `sdist` so the file is regenerated each time `sdist` is called and something in source files changed.