### PR TITLE
error: expected ‘)’ before ‘PRId64’

### DIFF
--- a/cystatsd/collector/statsd_proto.cpp
+++ b/cystatsd/collector/statsd_proto.cpp
@@ -1,5 +1,7 @@
 #include "statsd_proto.hpp"
 #include <cstring>
+
+#define __STDC_FORMAT_MACROS 1
 #include <inttypes.h>
 
 using namespace std;


### PR DESCRIPTION
In ubuntu 12.04 with g++ 4.9 error:
```
    cystatsd/collector/statsd_proto.cpp:57:28: error: expected ‘)’ before ‘PRId64’
         sprintf(intBuff, ":%+" PRId64 "|", value_);
```